### PR TITLE
`JsonAdaptedPersonTest` hotfix

### DIFF
--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -129,7 +129,8 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidFavourite_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(
-                VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_DEADLINE, VALID_TAGS, INVALID_FAVOURITE);
+                VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_DEADLINE, new ArrayList<>(VALID_NOTES.value),
+                VALID_TAGS, INVALID_FAVOURITE);
         String expectedMessage = Favourite.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
 


### PR DESCRIPTION
In `JsonAdaptedPersonTest`, there was a conflict where my previous PR #47 passed on my build, but failed after merge. Weijue's `notes` changes weren't pulled in by me. Though auto-merge was possible, my new test case for `JsonAdaptedPersonTest` did not include the `notes` in the constructor, causing the CI build to fail.