### PR TITLE
Change hashcode of AddressBook

### DIFF
--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -3,6 +3,7 @@ package seedu.address.model;
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
+import java.util.Objects;
 
 import javafx.collections.ObservableList;
 import seedu.address.model.person.Person;
@@ -169,6 +170,6 @@ public class AddressBook implements ReadOnlyAddressBook {
 
     @Override
     public int hashCode() {
-        return persons.hashCode();
+        return Objects.hash(persons, tags);
     }
 }


### PR DESCRIPTION
This PR fixes the currently incorrectly implemented AddressBook#hashCode method.

The hashCode is currently implemented by hashing only the `UniquePersonList`. With the introduction of `UniqueTagList` into `AddressBook`, having the same `UniquePersonList` and `UniqueTagList` should not have the same hashCode as an AddressBook with same `UniquePersonList` but different `UniqueTagList`.