### PR TITLE
Change findtag to work as a filter

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeadlineCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeadlineCommand.java
@@ -2,7 +2,6 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DEADLINE;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.List;
 
@@ -64,7 +63,6 @@ public class DeadlineCommand extends Command {
         }
 
         model.setPerson(personToAddDeadline, editedPerson);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(String.format(MESSAGE_ADD_DEADLINE_SUCCESS, personToAddDeadline));
     }
 

--- a/src/main/java/seedu/address/logic/commands/DeleteTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteTagCommand.java
@@ -50,6 +50,7 @@ public class DeleteTagCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+        model.clearActivatedTagList();
         model.clearDetailedContactView();
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         ObservableList<Person> allPersons = model.getFilteredPersonList();

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -7,7 +7,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.List;
 import java.util.Optional;
@@ -87,7 +86,6 @@ public class EditCommand extends Command {
         }
 
         model.setPerson(personToEdit, editedPerson);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedPerson));
     }
 

--- a/src/main/java/seedu/address/logic/commands/FavouriteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FavouriteCommand.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.List;
 import java.util.Set;
@@ -64,7 +63,6 @@ public class FavouriteCommand extends Command {
         Person editedPerson = createFavouritedPerson(personToFavourite, newFavouriteStatus);
 
         model.setPerson(personToFavourite, editedPerson);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(String.format(MESSAGE_FAVOURITE_PERSON_SUCCESS, editedPerson));
     }
 

--- a/src/main/java/seedu/address/logic/commands/FindTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindTagCommand.java
@@ -2,8 +2,11 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
+import javafx.collections.ObservableList;
 import seedu.address.commons.core.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
@@ -25,33 +28,49 @@ public class FindTagCommand extends Command {
 
     public static final String TAG_NOT_EXIST = "One or more tags do not exist";
 
-    private final TagContainsKeywordsPredicate predicate;
+    public static final String TAG_ALREADY_ACTIVATED = "One or more tags have already been selected";
 
-    public FindTagCommand(TagContainsKeywordsPredicate predicate) {
-        this.predicate = predicate;
+    private final List<String> keywords;
+
+    public FindTagCommand(List<String> keywords) {
+        this.keywords = keywords;
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         model.clearDetailedContactView();
-        model.clearActivatedTagList();
-        model.updateFilteredPersonList(predicate);
-        List<String> matchedKeywords = predicate.getMatchedKeyowrds();
 
         boolean hasAllTag = true;
-        for (String keyword : matchedKeywords) {
+        List<Tag> tagsToAdd = new ArrayList<>();
+        for (String keyword : keywords) {
+            Tag tagToAdd = new Tag(keyword);
             hasAllTag = hasAllTag && model.hasTag(new Tag(keyword));
+            boolean tagActivated = model.getActivatedTagList().contains(tagToAdd);
+
+            if (!hasAllTag) {
+                throw new CommandException(TAG_NOT_EXIST);
+            }
+
+            if (tagActivated) {
+                throw new CommandException(TAG_ALREADY_ACTIVATED);
+            }
+            tagsToAdd.add(tagToAdd);
         }
 
-        if (!hasAllTag) {
-            throw new CommandException(TAG_NOT_EXIST);
+        for (Tag tag : tagsToAdd) {
+            model.addActivatedTag(tag);
         }
 
-        for (String matched : matchedKeywords) {
-            Tag currTag = new Tag(matched);
-            model.addActivatedTag(currTag);
+        if (keywords.size() == 0) {
+            throw new CommandException(MESSAGE_USAGE);
         }
+        ObservableList<Tag> activatedTagList = model.getActivatedTagList();
+
+        TagContainsKeywordsPredicate predicate =
+                new TagContainsKeywordsPredicate(activatedTagList.stream().map(tag -> tag.tagName)
+                        .collect(Collectors.toList()));
+        model.updateFilteredPersonList(predicate);
 
         return new CommandResult(
                 String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
@@ -61,6 +80,7 @@ public class FindTagCommand extends Command {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof FindTagCommand // instanceof handles nulls
-                && predicate.equals(((FindTagCommand) other).predicate)); // state check
+                // && predicate.equals(((FindTagCommand) other).predicate)); // state check
+                && keywords.equals(((FindTagCommand) other).keywords)); // state check
     }
 }

--- a/src/main/java/seedu/address/logic/commands/HighImportanceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HighImportanceCommand.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.List;
 import java.util.Set;
@@ -68,7 +67,6 @@ public class HighImportanceCommand extends Command {
         Person editedPerson = createHighImportancePerson(highImportancePerson, highImportanceStatus);
 
         model.setPerson(highImportancePerson, editedPerson);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(String.format(MESSAGE_CHANGE_HIGH_IMPORTANCE_SUCCESS, editedPerson));
     }
 

--- a/src/main/java/seedu/address/logic/commands/NoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/NoteCommand.java
@@ -3,7 +3,6 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.List;
 
@@ -62,7 +61,6 @@ public class NoteCommand extends Command {
         }
         Person editedPerson = updateNotes(personToEdit, note);
         model.setPerson(personToEdit, editedPerson);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(generateSuccessMessage(editedPerson));
     }
 

--- a/src/main/java/seedu/address/logic/parser/FindTagCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindTagCommandParser.java
@@ -6,7 +6,6 @@ import java.util.Arrays;
 
 import seedu.address.logic.commands.FindTagCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.person.TagContainsKeywordsPredicate;
 
 /**
  * Parses input arguments and creates a new FindTagCommand object
@@ -27,7 +26,7 @@ public class FindTagCommandParser implements Parser<FindTagCommand> {
 
         String[] nameKeywords = trimmedArgs.split("\\s+");
 
-        return new FindTagCommand(new TagContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+        return new FindTagCommand(Arrays.asList(nameKeywords));
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/DeadlineCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeadlineCommandTest.java
@@ -62,6 +62,7 @@ public class DeadlineCommandTest {
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setPerson(firstPerson, editedPerson);
+        showPersonAtIndex(expectedModel, INDEX_FIRST_PERSON);
 
         assertCommandSuccess(deadlineCommand, model, expectedMessage, expectedModel);
     }

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -93,7 +93,9 @@ public class EditCommandTest {
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-        expectedModel.setPerson(model.getFilteredPersonList().get(0), editedPerson);
+        showPersonAtIndex(expectedModel, INDEX_FIRST_PERSON);
+        expectedModel.setPerson(model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased()), editedPerson);
+
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }

--- a/src/test/java/seedu/address/logic/commands/FavouriteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FavouriteCommandTest.java
@@ -58,6 +58,7 @@ class FavouriteCommandTest {
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.setPerson(personToFavourite, favouritedPerson);
+        showPersonAtIndex(expectedModel, INDEX_FIRST_PERSON);
 
         assertCommandSuccess(favouriteCommand, model, expectedMessage, expectedModel);
     }

--- a/src/test/java/seedu/address/logic/commands/FindTagCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindTagCommandTest.java
@@ -35,11 +35,6 @@ class FindTagCommandTest {
 
     @Test
     void equals() {
-        TagContainsKeywordsPredicate firstPredicate =
-                new TagContainsKeywordsPredicate(Collections.singletonList("first"));
-        TagContainsKeywordsPredicate secondPredicate =
-                new TagContainsKeywordsPredicate(Collections.singletonList("second"));
-
         List<String> firstKeywords = new ArrayList<>();
         firstKeywords.add("first");
         List<String> secondKeywords = new ArrayList<>();
@@ -84,8 +79,6 @@ class FindTagCommandTest {
         String expectedMessage = FindTagCommand.MESSAGE_USAGE;
         List<String> emptyKeywords = new ArrayList<>();
         FindTagCommand command = new FindTagCommand(emptyKeywords);
-        TagContainsKeywordsPredicate predicate = new TagContainsKeywordsPredicate(emptyKeywords);
-        expectedModel.updateFilteredPersonList(predicate);
         assertCommandFailure(command, model, expectedMessage);
 
     }

--- a/src/test/java/seedu/address/logic/parser/FindTagCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindTagCommandParserTest.java
@@ -9,7 +9,6 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.FindTagCommand;
-import seedu.address.model.person.TagContainsKeywordsPredicate;
 
 public class FindTagCommandParserTest {
 
@@ -25,7 +24,7 @@ public class FindTagCommandParserTest {
     public void parse_validArgs_returnsFindTagCommand() {
         // no leading and trailing whitespaces
         FindTagCommand expectedFindTagCommand =
-                new FindTagCommand(new TagContainsKeywordsPredicate(Arrays.asList("friends", "colleagues")));
+                new FindTagCommand(Arrays.asList("friends", "colleagues"));
         assertParseSuccess(parser, "friends colleagues", expectedFindTagCommand);
 
         // multiple whitespaces between keywords


### PR DESCRIPTION
This PR changes the `findtag` command to work as a filter. 

**Each** `findtag` command activates a tag to be searched.
e.g. 
1. `findtag friends` adds `friends` as a tag to be searched for
1. `findtag colleagues` adds `colleagues` to pre-existing search, now containing both `colleagues` and `friends`

